### PR TITLE
feat: add setup script for non-Docker users to configure log forwarding

### DIFF
--- a/setup-log-forwarding.sh
+++ b/setup-log-forwarding.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "Installing prerequisites..."
+sudo apt-get update -y
+sudo apt-get install -y openjdk-11-jre wget curl
+
+echo "Installing Logstash..."
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+sudo sh -c 'echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" > /etc/apt/sources.list.d/elastic-7.x.list'
+sudo apt-get update && sudo apt-get install -y logstash
+
+echo "Setting up configuration files..."
+mkdir -p /etc/logstash/conf.d/
+curl -o /etc/logstash/conf.d/logstash.conf https://raw.githubusercontent.com/softwares-compound/Client-Cd-109/main/logstash.conf
+
+echo "Setting up Logstash service..."
+sudo systemctl enable logstash
+
+echo "Starting Logstash service..."
+sudo systemctl start logstash
+sudo systemctl status logstash
+
+echo "Log forwarding setup completed!"


### PR DESCRIPTION
Added a setup script for non-Docker users to easily configure log forwarding. The script installs Logstash, sets up the configuration, and starts the service with minimal effort.